### PR TITLE
Add env for allowed email suffixes, initial admin email and email whi…

### DIFF
--- a/massage-booking-system-backend/services/passport.js
+++ b/massage-booking-system-backend/services/passport.js
@@ -30,20 +30,28 @@ passport.use(
       // or something like that which should fail
 
       User.findOne({ googleId: profile.id }).then(foundUser => {
-
         if (foundUser) {
           // User has already been registered, continue with existing user
           done(null, foundUser)
         } else {
           // New user registration, add to database
-          new User({
-            googleId: profile.id,
-            name: profile.displayName,
-            email: profile.emails[0].value,
-            avatarUrl: profile.photos[0].value
-          })
-            .save()
-            .then(createdUser => done(null, createdUser))
+          if (profile.emails[0].value.split('@')[1] === config.EMAIL_SUFFIX || config.EMAIL_WHITELIST.includes(profile.emails[0].value)) {
+            let admin = false
+            if (profile.emails[0].value === config.INITIAL_ADMIN) {
+              admin = true
+            }
+            new User({
+              googleId: profile.id,
+              name: profile.displayName,
+              email: profile.emails[0].value,
+              admin: admin,
+              avatarUrl: profile.photos[0].value
+            })
+              .save()
+              .then(createdUser => done(null, createdUser))
+          } else {
+            done(null, false, { message: 'email suffix not allowed' })
+          }
         }
       })
     }

--- a/massage-booking-system-backend/utils/config.js
+++ b/massage-booking-system-backend/utils/config.js
@@ -7,6 +7,11 @@ let MONGODB_URI = process.env.MONGODB_URI
 let CLIENT_ID = process.env.CLIENT_ID
 let CLIENT_SECRET = process.env.CLIENT_SECRET
 let COOKIE_KEY = process.env.COOKIE_KEY
+let EMAIL_SUFFIX = process.env.EMAIL_SUFFIX
+let INITIAL_ADMIN = process.env.INITIAL_ADMIN
+let EMAIL_WHITELIST = process.env.EMAIL_WHITELIST.split(',')
+console.log('EMAIL_WHITELIST : ', EMAIL_WHITELIST)
+
 
 if (process.env.NODE_ENV === 'test') {
   MONGODB_URI = process.env.TEST_MONGODB_URI
@@ -18,4 +23,7 @@ module.exports = {
   CLIENT_ID,
   CLIENT_SECRET,
   COOKIE_KEY,
+  EMAIL_SUFFIX,
+  INITIAL_ADMIN,
+  EMAIL_WHITELIST
 }


### PR DESCRIPTION
…telist. Implement these rules for the google auth process.

New envs:

EMAIL_SUFFIX : sets a email suffix (e.g. gmail.com) that are whitelisted to access the app

INITIAL_ADMIN : accepts a single email that will be granted admin status (e.g. admin@admin.com)

EMAIL_WHITELIST : accepts a list of emails separated by "," that are allowed to log-in even if the emails don't end in suffix specified by EMAIL_SUFFIX env (e.g. masseuse@massage.com,masseur@massage.com)